### PR TITLE
Fix typo in code snippet

### DIFF
--- a/manuscript/book.org
+++ b/manuscript/book.org
@@ -887,7 +887,7 @@ can be rewritten as async
 #+BEGIN_SRC scala
   def getA: Future[Int] = ...
   def error(msg: String): Future[Nothing] =
-    Future.fail(new RuntimeException(msg))
+    Future.failed(new RuntimeException(msg))
 
   for {
     a <- getA

--- a/manuscript/complete.md
+++ b/manuscript/complete.md
@@ -436,7 +436,7 @@ can be rewritten as async
 ~~~~~~~~
   def getA: Future[Int] = ...
   def error(msg: String): Future[Nothing] =
-    Future.fail(new RuntimeException(msg))
+    Future.failed(new RuntimeException(msg))
   
   for {
     a <- getA


### PR DESCRIPTION
Changed `Future.fail` to `Future.failed`.