### PR TITLE
correct IO's flatMap method

### DIFF
--- a/src/main/scala/chapter1.scala
+++ b/src/main/scala/chapter1.scala
@@ -88,7 +88,7 @@ object Runner {
 
 final class IO[A] private (val interpret: () => A) {
   def map[B](f: A => B): IO[B]         = IO(f(interpret()))
-  def flatMap[B](f: A => IO[B]): IO[B] = f(interpret())
+  def flatMap[B](f: A => IO[B]): IO[B] = IO(f(interpret()).interpret())
 }
 object IO {
   def apply[A](a: =>A): IO[A] = new IO(() => a)


### PR DESCRIPTION
Hello. I am really enjoying the book, but I found that in chapter 1, as the code stands, when echo[IO] runs, it actually carries out I/O rather than building an IO object! i.e. it does it before the end of the world, when delayed.interpret is called. This is happening because IO's flatMap is incorrect. We can see the problem if we compare IO's flatMap with the flatMap of the IO in the following code by John A. De Goes': https://gist.github.com/jdegoes/1b43f43e2d1e845201de853815ab3cb9#file-fpmax-scala-L373

If I add println("before the end of the world") before the line that does delayed.interpret(), I get the following output:

input for echo[Now]
input for echo[Now]
input for echo[Future]
input for echo[Future]
input for echo[IO]
input for echo[IO]
before the end of the world

Process finished with exit code 0

After the correction I am proposing (John found the problem straight away) it seems to work fine:

input for echo[Now]
input for echo[Now]
input for echo[Future]
input for echo[Future]
before the end of the world
input for echo[IO]
input for echo[IO]

Process finished with exit code 0