### PR TITLE
Typo "UriQuery" to "UrlQuery"

### DIFF
--- a/manuscript/book.org
+++ b/manuscript/book.org
@@ -2929,7 +2929,7 @@ we wish to convert:
   import UrlEncodedWriter.ops._
   object AuthRequest {
     implicit val query: UrlQueryWriter[AuthRequest] = { a =>
-      UriQuery(List(
+      UrlQuery(List(
         ("redirect_uri"  -> a.redirect_uri.value),
         ("scope"         -> a.scope),
         ("client_id"     -> a.client_id),


### PR DESCRIPTION
```final case class UrlQuery(params: List[(String, String)])``` is created line 2840