### PR TITLE
Chapter 4, follow the journey along with the source code

### DIFF
--- a/manuscript/book.org
+++ b/manuscript/book.org
@@ -2859,6 +2859,9 @@ object UrlEncodedWriter {
   implicit val string: UrlEncodedWriter[String] =
     (s => Refined.unsafeApply(URLEncoder.encode(s, "UTF-8")))
 
+  implicit val url: UrlEncodedWriter[String Refined Url] =
+    (s => s.value.toUrlEncoded)
+
   implicit val long: UrlEncodedWriter[Long] =
     (s => Refined.unsafeApply(s.toString))
 
@@ -2940,7 +2943,7 @@ we wish to convert:
   }
   object AccessRequest {
     implicit val encoded: UrlEncodedWriter[AccessRequest] = { a =>
-      List(
+      IList(
         "code"          -> a.code.toUrlEncoded,
         "redirect_uri"  -> a.redirect_uri.toUrlEncoded,
         "client_id"     -> a.client_id.toUrlEncoded,
@@ -2952,7 +2955,7 @@ we wish to convert:
   }
   object RefreshRequest {
     implicit val encoded: UrlEncodedWriter[RefreshRequest] = { r =>
-      List(
+      IList(
         "client_secret" -> r.client_secret.toUrlEncoded,
         "refresh_token" -> r.refresh_token.toUrlEncoded,
         "client_id"     -> r.client_id.toUrlEncoded,
@@ -2983,7 +2986,7 @@ trait JsonClient[F[_]] {
   def post[P: UrlEncodedWriter, A: JsDecoder](
     uri: String Refined Url,
     payload: P,
-    headers: IList[(String, String]
+    headers: IList[(String, String] = IList.empty
   ): F[A]
 }
 #+END_SRC


### PR DESCRIPTION
- `.toUrlEncoded` is defined on `IList` line 2868, rather than `List`
- `a.redirect_uri.toUrlEncoded` requires knowledge how to convert `String Refined Url`
- `JsonClient.post` is used without headers argument on line 3070, set it to default empty `IList`