### PR TITLE
StateMonad -> MonadState

### DIFF
--- a/manuscript/book.org
+++ b/manuscript/book.org
@@ -12407,7 +12407,7 @@ object StateTask {
 }
 #+END_SRC
 
-We can make use of this optimised =StateMonad= implementation in a =SafeApp=,
+We can make use of this optimised =MonadState= implementation in a =SafeApp=,
 where our =.program= depends on optimised MTL typeclasses:
 
 #+BEGIN_SRC scala


### PR DESCRIPTION
maybe this was intended, but putting it in backticks indicates a valid type, and there is no `StateMonad` type that I know of, so I assume its a typo.

Technical question: is updating book.org enough? Translators (according to guide) delete book.org and translate based on `.md` only. But I'm submitting this changes through github webpage, which doesn't make it easy to make changes in multiple files, and I'm too lazy to do this any other way.
